### PR TITLE
fix: resolve System.Text.Encodings.Web version conflict

### DIFF
--- a/src/ZavaStorefront.csproj
+++ b/src/ZavaStorefront.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
   <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.1" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
Bumps \System.Text.Encodings.Web\ from 4.5.1 to 4.7.2 to resolve NuGet error **NU1605** (package downgrade detected).

## Problem
\Microsoft.ApplicationInsights.AspNetCore\ 2.22.0 requires \System.Text.Encodings.Web\ >= 4.7.2, but the project referenced version 4.5.1, causing the ACR cloud build to fail during \dotnet restore\.

## Fix
Updated the package reference in \ZavaStorefront.csproj\ to version 4.7.2 (minimum compatible version).

## Testing
- Local \dotnet build\ succeeds
- ACR cloud build should now pass